### PR TITLE
ROS2 setup (with GUI) via Docker container

### DIFF
--- a/setup/ros2/ROS2.Dockerfile
+++ b/setup/ros2/ROS2.Dockerfile
@@ -1,0 +1,1 @@
+FROM osrf/ros:humble-desktop-full

--- a/setup/ros2/ROS2.Dockerfile
+++ b/setup/ros2/ROS2.Dockerfile
@@ -1,1 +1,16 @@
+ARG DOMAIN_ID=42
+
 FROM osrf/ros:humble-desktop-full
+
+# See https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html for details
+RUN apt-get update -y; \
+		apt-get upgrade -y; \
+		source /opt/ros/humble/setup.bash; \
+		echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc; \
+		export ROS_DOMAIN_ID=${ROS_DOMAIN_ID}; \
+		echo "export ROS_DOMAIN_ID=${DOMAIN_ID}" >> ~/.bashrc
+
+RUN apt install ros-humble-turtlesim
+
+
+

--- a/setup/ros2/SETUP.md
+++ b/setup/ros2/SETUP.md
@@ -1,0 +1,24 @@
+# ROS2 Setup
+
+This directory contains two shell scripts: `build_ros2.sh` that builds the ROS2
+Docker container image from `ROS2.Dockerfile` and `run_ros2.sh` that runs the
+container. Running the following will perform all steps necessary for first time
+setup.
+
+```bash
+bash build_ros2.sh
+bash run_ros2.sh
+```
+
+If you want to run the ROS2 environment again, use:
+
+```bash
+bash run_ros2.sh
+```
+
+I'll look into persistent ROS2 containers and/or filesystem mounting soon. -
+Spandan
+
+## Relevant Sources
+
+https://hub.docker.com/r/osrf/ros/tags

--- a/setup/ros2/SETUP.md
+++ b/setup/ros2/SETUP.md
@@ -16,6 +16,8 @@ If you want to run the ROS2 environment again, use:
 bash run_ros2.sh
 ```
 
+Note that you might have to run `docker stop ros2` before running the above.
+
 I'll look into persistent ROS2 containers and/or filesystem mounting soon. -
 Spandan
 

--- a/setup/ros2/build_ros2.sh
+++ b/setup/ros2/build_ros2.sh
@@ -1,0 +1,1 @@
+docker build --platform linux/amd64 -t ros2 - < ROS2.Dockerfile

--- a/setup/ros2/run_ros2.sh
+++ b/setup/ros2/run_ros2.sh
@@ -1,1 +1,2 @@
-docker run --platform linux/amd64 -it --rm --name ros2 ros2
+xhost +local:docker
+docker run --platform linux/amd64 -it --rm --name ros2 --pid=host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro ros2

--- a/setup/ros2/run_ros2.sh
+++ b/setup/ros2/run_ros2.sh
@@ -1,0 +1,1 @@
+docker run --platform linux/amd64 -it --rm --name ros2 ros2


### PR DESCRIPTION
Adds scripts and a quickstart tutorial in `setup/root` that guides you through launching ROS2 in a Docker container. 