### PR TITLE
allow microcontrollers to interface right on speedystart

### DIFF
--- a/.vscode
+++ b/.vscode
@@ -1,0 +1,11 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}
+

--- a/setup/ros2/ROS2.Dockerfile
+++ b/setup/ros2/ROS2.Dockerfile
@@ -5,16 +5,23 @@ CMD ["bash"]
 # See https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html for details
 RUN apt-get update -y; \
 		apt-get upgrade -y; \
-		source /opt/ros/humble/setup.bash; \
-		echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc; \
-		export ROS_DOMAIN_ID=${DOMAIN_ID}; \
-		echo "export ROS_DOMAIN_ID=${DOMAIN_ID}" >> ~/.bashrc; \
 		apt-get install tmux -y; \
-		echo "tmux set -g mouse on" >> ~/.bashrc
+		apt-get install wget -y; \
+		mkdir -p /etc/udev/rules.d; \
+    wget -P /etc/udev/rules.d/ https://www.pjrc.com/teensy/00-teensy.rules
+
+RUN useradd -m cpss && echo "cpss:cpss" | chpasswd && adduser cpss sudo
 
 WORKDIR /home/pwd
 
 RUN apt install ros-humble-turtlesim
+
+USER cpss
+RUN echo "tmux set -g mouse on" >> ~/.bashrc; \
+		source /opt/ros/humble/setup.bash; \
+		export ROS_DOMAIN_ID=${DOMAIN_ID}; \
+		echo "export ROS_DOMAIN_ID=${DOMAIN_ID}" >> ~/.bashrc; \
+		echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 
 ENTRYPOINT ["tmux", "new", "-s", "ros2"]
 

--- a/setup/ros2/run_ros2.sh
+++ b/setup/ros2/run_ros2.sh
@@ -2,4 +2,4 @@ imagename="cpss-ros2"
 
 docker build --platform linux/amd64 -t $imagename - < setup/ros2/ROS2.Dockerfile
 xhost +local:docker
-docker run --platform linux/amd64 -it --rm --name $imagename --pid=host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro -v $(pwd):/home/pwd $imagename
+docker run --platform linux/amd64 -it --rm --name $imagename --pid=host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro -v $(pwd):/home/pwd -v /dev:/dev --privileged $imagename


### PR DESCRIPTION
Docker script now mounts /dev directory and runs with --privileged. VSCode file now includes PlatformIO. Container spins up with new account, cpss.